### PR TITLE
Extra Options added to select SSL connection and to add a login suffix

### DIFF
--- a/plib/hooks/Auth.php
+++ b/plib/hooks/Auth.php
@@ -6,11 +6,17 @@ class Modules_LdapAuth_Auth extends pm_Hook_Auth
     public function auth($login, $password)
     {
         $ch = curl_init();
+        $protocol = "ldap://";
+        $port = "389";
+        if (pm_Settings::get('ssl') == true) {
+            $protocol = "ldaps://";
+            $port = "636";
+        }
 
-        curl_setopt($ch, CURLOPT_URL, 'ldap://' . pm_Settings::get('host') . ':389/');
+        curl_setopt($ch, CURLOPT_URL, $protocol . pm_Settings::get('host') . ":" . $port);
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_USERPWD, pm_Settings::get('loginPrefix') . "$login:$password");
+        curl_setopt($ch, CURLOPT_USERPWD, pm_Settings::get('loginPrefix') . $login . pm_Settings::get('loginSuffix') . ":" . $password);
         $result = curl_exec($ch);
         curl_close($ch);
 

--- a/plib/library/Form/Settings.php
+++ b/plib/library/Form/Settings.php
@@ -15,9 +15,19 @@ class Modules_LdapAuth_Form_Settings extends pm_Form_Simple
             'value' => pm_Settings::get('host'),
         ));
 
+        $this->addElement('checkbox', 'ssl', array(
+            'label' => $this->lmsg('fieldSsl'),
+            'value' => pm_Settings::get('ssl'),
+        ));
+
         $this->addElement('text', 'loginPrefix', array(
             'label' => $this->lmsg('fieldLoginPrefix'),
             'value' => pm_Settings::get('loginPrefix', 'DOMAIN\\'),
+        ));
+
+        $this->addElement('text', 'loginSuffix', array(
+            'label' => $this->lmsg('fieldLoginSuffix'),
+            'value' => pm_Settings::get('loginSuffix'),
         ));
 
         if (version_compare(pm_ProductInfo::getVersion(), '12.5.29', '>=')) {
@@ -37,7 +47,9 @@ class Modules_LdapAuth_Form_Settings extends pm_Form_Simple
         $values = $this->getValues();
         pm_Settings::set('enable', (bool)$values['enable']);
         pm_Settings::set('host', $values['host']);
+        pm_Settings::set('ssl', $values['ssl']);
         pm_Settings::set('loginPrefix', $values['loginPrefix']);
+        pm_Settings::set('loginSuffix', $values['loginSuffix']);
 
         if (version_compare(pm_ProductInfo::getVersion(), '12.5.29', '>=')) {
             pm_Settings::set('disableNativeAuth', (bool)$values['disableNativeAuth']);

--- a/plib/resources/locales/en-US.php
+++ b/plib/resources/locales/en-US.php
@@ -5,6 +5,8 @@ $messages = [
     'settingsSaved' => 'The settings were saved.',
     'fieldEnable' => 'Enable',
     'fieldHost' => 'Host',
+    'fieldSsl' => 'Enable SSL',
     'fieldLoginPrefix' => 'Login prefix',
+    'fieldLoginSuffix' => 'Login suffix',
     'fieldDisableNativeAuth' => 'Disable Plesk native authentication',
 ];


### PR DESCRIPTION
Please consider these changes. I have added option to use secure connection  and added the posibility to add a suffix to the login. 
with the added suffix we can now send a string like so: cn=\<login\>,cn=users,dc=example,dc=com
where "cn=" is the prefix and ",cn=users,dc=example,dc=com" is the suffix.

Also noticed that when disabling the native auth (making "breakChainOnFailure" return true) the authentication fails. I have not included a fix for this but this is probably something that should be fixed in the future.
