### PR TITLE
Add error logging for the cURL request

### DIFF
--- a/plib/hooks/Auth.php
+++ b/plib/hooks/Auth.php
@@ -17,7 +17,11 @@ class Modules_LdapAuth_Auth extends pm_Hook_Auth
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_USERPWD, pm_Settings::get('loginPrefix') . $login . pm_Settings::get('loginSuffix') . ":" . $password);
+        \pm_Log::debug('Sending a request to the LDAP server');
         $result = curl_exec($ch);
+        if ($result === false) {
+            \pm_Log::info('Communication with LDAP server failed: ' . curl_error($ch));
+        }
         curl_close($ch);
 
         return false !== $result;


### PR DESCRIPTION
Currently, troubleshooting issues with this extension without direct access to the affected environment is impossible: no errors are logged by it whatsoever.

This PR introduces minimal necessary logging of the request, so it would be possible to provide support by asking for log files, without having to resort to the code modifications on the client side.